### PR TITLE
durationToHHMMSS falls back to '0:00' instead of NaN

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,8 +39,9 @@ export const durationToHHMMSS = duration => {
   let totalSeconds = duration
   const hours = Math.floor(totalSeconds / 3600)
   totalSeconds %= 3600
-  const minutes = Math.floor(totalSeconds / 60)
-  const seconds = Math.floor(totalSeconds % 60)
+  const minutes = Math.floor(totalSeconds / 60) || 0
+  const seconds = Math.floor(totalSeconds % 60) || 0
+
 
   return [hours, hours ? addZero(minutes) : String(minutes), addZero(seconds)].filter(x => x).join(':')
 }


### PR DESCRIPTION
Great project!

While the audio is loading, the duration displays 'NaN:NaN'. This change causes the playback duration to fallback to '00:00'.