### PR TITLE
Feature/column scroll

### DIFF
--- a/components/Column.js
+++ b/components/Column.js
@@ -7,9 +7,9 @@ class Column extends Component {
   }
 
   componentDidMount() {
-    document.querySelectorAll('.column .active').forEach(activeRow => {
+    Array.prototype.forEach.call(document.querySelectorAll('.column .active'), activeRow => {
       activeRow.scrollIntoView();
-    })
+    });
   }
 
   render() {

--- a/components/Column.js
+++ b/components/Column.js
@@ -1,7 +1,20 @@
 import Row from './Row'
+import { Component } from 'react';
 
-export default ({ children, heading, loading, loadingAmount = 20, className }) => (
-  <div className={`column ${className}`}>
+class Column extends Component {
+  constructor (props) {
+    super(props);
+  }
+
+  componentDidMount() {
+    document.querySelectorAll('.column .active').forEach(activeRow => {
+      activeRow.scrollIntoView();
+    })
+  }
+
+  render() {
+    const loadingAmount = this.props.loadingAmount ? this.props.loadingAmount : 20;
+    return <div className={`column ${this.props.className}`}>
     <style jsx>{`
       .column {
         display: flex;
@@ -45,7 +58,10 @@ export default ({ children, heading, loading, loadingAmount = 20, className }) =
         overflow-y: initial;
       }
     `}</style>
-    {heading && <div className="heading">{heading}</div>}
-    <div className="column-content">{loading ? new Array(loadingAmount).fill(null).map((i, idx) => <Row key={idx} loading />) : children}</div>
-  </div>
-)
+    {this.props.heading && <div className="heading">{this.props.heading}</div>}
+    <div className="column-content">{this.props.loading ? new Array(loadingAmount).fill(null).map((i, idx) => <Row key={idx} loading />) : this.props.children}</div>
+  </div>;
+  }
+}
+
+export default Column;


### PR DESCRIPTION
Addresses issue #14 

On page load, Columns scroll to their active row defined by url, ie https://relisten.net/dark-star-orchestra/2011/08/16/white-rabbit?source=8600

Column is changed from function to class component so we can hook into ComponentDidMount lifecycle method.

Note that (cached?) active css classes still appear when loading relisten.net without a artist/year/show/song route. This change does NOT scroll columns in those scenarios.