### PR TITLE
rebrand 'Live' to 'Recently Streamed'

### DIFF
--- a/components/Menu.js
+++ b/components/Menu.js
@@ -6,13 +6,13 @@ export default () => (
   <div className="menu">
     <style jsx>{`
       .menu {
-        width: 120px;
+        width: 160px;
       }
     `}</style>
     <Column className="let-flow">
       <Row baseHrefOverride="/about">About</Row>
       <Row baseHrefOverride="/today">Today</Row>
-      <Row baseHrefOverride="/live">Live</Row>
+      <Row baseHrefOverride="/recent-streams">Recent Streams</Row>
       <Row baseHrefOverride="/sonos">Sonos</Row>
       <Row baseHrefOverride="/ios">iOS</Row>
       <Row baseHrefOverride="/chat">Chat</Row>

--- a/components/Navigation.js
+++ b/components/Navigation.js
@@ -132,7 +132,7 @@ class Navigation extends Component {
         </div>
         <div className="right nav desktop">
           <div><Link href="/today" prefetch><a>TIH</a></Link></div>
-          <div><Link href="/live" prefetch><a>LIVE</a></Link></div>
+          <div><Link href="/recent-streams" prefetch><a>RECENT STREAMS</a></Link></div>
           <div><Link href="/chat" prefetch><a>CHAT</a></Link></div>
           <div><Link href="/ios" prefetch><a>iOS</a></Link></div>
           <div><Link href="/sonos" prefetch><a>SONOS</a></Link></div>

--- a/lib/customRoutes.js
+++ b/lib/customRoutes.js
@@ -2,7 +2,7 @@ const customRoutes = [
   'about',
   'ios',
   'today',
-  'live',
+  'recent-streams',
   'favicon\.ico', // eslint-disable-line no-useless-escape
   '_next',
 ];

--- a/lib/player.js
+++ b/lib/player.js
@@ -3,7 +3,7 @@ import Gapless from '../static/gapless';
 
 import { splitShowDate } from './utils';
 
-import { scrobblePlay } from '../redux/modules/live';
+import { scrobblePlay } from '../redux/modules/recent-streams';
 import { updatePlayback } from '../redux/modules/playback';
 
 // Returns a function, that, when invoked, will only be triggered at most once

--- a/pages/recent-streams.js
+++ b/pages/recent-streams.js
@@ -4,7 +4,7 @@ import { connect } from 'react-redux';
 
 import Layout from '../layouts';
 
-import { fetchLive } from '../redux/modules/live';
+import { fetchRecentStreams } from '../redux/modules/recent-streams';
 
 import LiveTrack from '../components/LiveTrack';
 
@@ -20,22 +20,22 @@ const keyFn = (item) => {
   return item && item.track && item.track.track && item.track.track.id;
 };
 
-class Live extends Component {
+class RecentStreams extends Component {
   state = {
     isMounted: false,
     lastSeenId: null,
   }
 
   static async getInitialProps({ store, isServer, pathname, query }) {
-    await store.dispatch(fetchLive());
+    await store.dispatch(fetchRecentStreams());
     return {
-      live: store.getState().live,
+      recentStreams: store.getState().recentStreams,
     };
   }
 
   componentDidMount() {
     this.intervalId = setInterval(async () => {
-      const action = await this.props.dispatch(fetchLive());
+      const action = await this.props.dispatch(fetchRecentStreams());
 
       if (action.data.length) {
         this.setState({ lastSeenId: action.data.slice(-1)[0].id });
@@ -51,17 +51,17 @@ class Live extends Component {
 
   render() {
     const { isMounted, lastSeenId } = this.state;
-    const { live } = this.props;
+    const { recentStreams } = this.props;
 
     return (
-      <Layout navPrefix="TO" navSubtitle="Recently Played" navURL="/live">
+      <Layout navPrefix="TO" navSubtitle="Recently Streamed" navURL="/recentstreams">
         <Head>
-          <title>Live | Relisten</title>
+          <title>Recently Streamed | Relisten</title>
         </Head>
         <div className="page-container">
-          <h1>Recently Played</h1>
+          <h1>Recently Streamed</h1>
 
-          {uniqBy(live.data, keyFn).map(data =>
+          {uniqBy(recentStreams.data, keyFn).map(data =>
             <LiveTrack {...data} key={data.track.track.id} isFirstRender={!isMounted} isLastSeen={lastSeenId === data.id} />
           )}
         </div>
@@ -79,4 +79,4 @@ class Live extends Component {
 
 }
 
-export default connect(({ live }) => ({ live }))(Live);
+export default connect(({ recentStreams }) => ({ recentStreams }))(RecentStreams);

--- a/redux/modules/index.js
+++ b/redux/modules/index.js
@@ -7,7 +7,7 @@ import tapes from './tapes';
 
 import app from './app';
 import playback from './playback';
-import live from './live';
+import recentStreams from './recent-streams';
 import today from './today';
 
 export default combineReducers({
@@ -17,6 +17,6 @@ export default combineReducers({
   tapes,
   playback,
   app,
-  live,
+  recentStreams,
   today,
 });

--- a/redux/modules/recent-streams.js
+++ b/redux/modules/recent-streams.js
@@ -1,5 +1,5 @@
-const REQUEST_LIVE = 'live/REQUEST_LIVE';
-const RECEIVE_LIVE = 'live/RECEIVE_LIVE';
+const REQUEST_RECENT_STREAMS = 'recent-streams/REQUEST_RECENT_STREAMS';
+const RECEIVE_RECENT_STREAMS = 'recent-streams/RECEIVE_RECENT_STREAMS';
 
 const defaultState = {
   data: [],
@@ -10,7 +10,7 @@ const defaultState = {
 
 export default function counter(state = defaultState, action) {
   switch (action.type) {
-  case REQUEST_LIVE:
+  case REQUEST_RECENT_STREAMS:
     return {
       data: state.data,
       meta: {
@@ -19,7 +19,7 @@ export default function counter(state = defaultState, action) {
         error: false,
       },
     };
-  case RECEIVE_LIVE:
+  case RECEIVE_RECENT_STREAMS:
     return {
       data: [...action.data.reverse(), ...state.data],
       meta: {
@@ -33,24 +33,24 @@ export default function counter(state = defaultState, action) {
   }
 }
 
-export function requestLive() {
+export function requestRecentStreams() {
   return {
-    type: REQUEST_LIVE,
+    type: REQUEST_RECENT_STREAMS,
   };
 }
 
-export function receiveLive(data) {
+export function receiveRecentStreams(data) {
   return {
-    type: RECEIVE_LIVE,
+    type: RECEIVE_RECENT_STREAMS,
     data,
   };
 }
 
-export function fetchLive() {
+export function fetchRecentStreams() {
   return async (dispatch, getState) => {
-    dispatch(requestLive());
+    dispatch(requestRecentStreams());
 
-    const lastSeen = getState().live.data[0];
+    const lastSeen = getState().recentStreams.data[0];
     let paramsStr = '';
 
     if (lastSeen) {
@@ -60,7 +60,7 @@ export function fetchLive() {
     const json = await fetch(`https://relistenapi.alecgorge.com/api/v2/live/history${paramsStr}`)
       .then(res => res.json());
 
-    return dispatch(receiveLive(json));
+    return dispatch(receiveRecentStreams(json));
   };
 }
 


### PR DESCRIPTION
Hi there, first time contributor here. Just want to say how much I appreciate the work done on this project so far. Relisten is a fantastic app that I use often.

This pull request is in response to [Issue #23](https://github.com/RelistenNet/relisten-web/issues/23). My changes effectively rebrand of the 'Live' page to be called 'Recently Streamed' across the project. I thought 'recently streamed' was perhaps more clear than 'recently played', which could be confused with 'recently performed'. Let me know your thoughts on this and any other feedback you have.

Cheers,
Adam