### PR TITLE
fix: CSS classes for Web Scrobbler extension

### DIFF
--- a/src/components/Player.tsx
+++ b/src/components/Player.tsx
@@ -93,9 +93,9 @@ const Player = ({ artistSlugsToName }: Props) => {
           onClick={() => player.togglePlayPause()}
         >
           {playback.activeTrack.isPaused ? (
-            <PlayIcon size={20} className="fill-foreground-muted active:fill-gray-800" />
+            <PlayIcon size={20} className="fas fa fa-play fill-foreground-muted active:fill-gray-800" />
           ) : (
-            <PauseIcon size={20} className="fill-foreground-muted active:fill-gray-800" />
+            <PauseIcon size={20} className="fas fa fa-pause fill-foreground-muted active:fill-gray-800" />
           )}
         </Flex>
       )}


### PR DESCRIPTION

Seems that [this PR](https://github.com/RelistenNet/relisten-web/commit/60262071c4777cfcaabcb867497f37798180264b#diff-b0f1f22a26b37c552954f7daf0d66252993b00f57b80f9b55df8e8cdf5fd9430R91-R95) removed the `fa` classes from the play/pause button, so the Web Scrobbler browser extension can no longer detect when the site is playing/paused. See https://github.com/web-scrobbler/web-scrobbler/issues/4048 / https://github.com/RelistenNet/relisten-web/pull/70 for previous context.

I checked by manually editing the DOM to include these classes in my browser, and then my track scrobbles.

<img width="2392" height="552" alt="CleanShot 2025-10-20 at 16 44 04@2x" src="https://github.com/user-attachments/assets/88a8c702-feee-4363-9f1f-af246f4cff66" />
