### PR TITLE
Update GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -18,13 +18,13 @@ jobs:
     environment: relisten3
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -41,7 +41,7 @@ jobs:
           echo "package=${IMAGE_NAME#relistennet/}" >> "$GITHUB_OUTPUT"
 
       - name: Build and push image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64
@@ -109,7 +109,7 @@ jobs:
           version: latest
 
       - name: Set up kubectl
-        uses: azure/setup-kubectl@v4
+        uses: azure/setup-kubectl@v5
         with:
           version: v1.36.2
 

--- a/.github/workflows/prs.js.yml
+++ b/.github/workflows/prs.js.yml
@@ -18,12 +18,12 @@ jobs:
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: pnpm/action-setup@v2
+    - uses: actions/checkout@v6
+    - uses: pnpm/action-setup@v5
       with:
         version: 10
     - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'pnpm'


### PR DESCRIPTION
## What changed

- Upgraded the image/deploy workflow's JavaScript actions to their current Node.js 24-based major versions.
- Upgraded the PR build's checkout, pnpm setup, and Node setup actions to Node.js 24-based majors.
- Preserved all triggers, permissions, action inputs, build commands, and deployment behavior.

## Why

GitHub now warns when Node.js 20-or-older action runtimes are forced onto Node.js 24. Updating the action majors removes the deprecated runtime path.

## Validation

- `actionlint` 1.7.12
- YAML parsing
- `git diff --check`
- Verified each selected action major declares `using: node24`

The deployment workflow was not dispatched because it publishes an image and restarts production. The PR build will exercise the CI path.