### PR TITLE
Browser session foundation v2 (replacement for #108)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Our Sonos app is on the Sonos store and also open source @ https://github.com/Re
   $ npm start
 ```
 
+For sign-in / favorites development see [docs/dev-session.md](docs/dev-session.md).
+
 ## License
 
 AGPL3

--- a/dev/sessionDevServer.ts
+++ b/dev/sessionDevServer.ts
@@ -13,18 +13,12 @@ import type { ServerOptions } from 'vite';
  * dev Vite's built-in proxy does.
  *
  * Enabled by `pnpm dev:session` (RELISTEN_WEB_SESSION=local|production).
- * Plain `pnpm dev` is unaffected.
+ * Plain `pnpm dev` is unaffected. The actual path forwarding lives in
+ * src/lib/session/proxy.ts (called from app/proxy.ts): timber's dev middleware
+ * runs before Vite's `server.proxy`, so a Vite-level proxy never sees these requests.
  */
 
 export const LOCAL_WEB_ORIGIN = 'https://web.relisten.localhost:5173';
-const LOCAL_USER_SERVICE = 'https://accounts.relisten.localhost:5443';
-
-export const SESSION_PROXY_ROUTES = [
-  '^/auth/session(/|$)',
-  '^/api/user/v1/csrf$',
-  '^/v1/me$',
-  '^/v1/library(/|$)',
-];
 
 export function tlsDirectory(env: NodeJS.ProcessEnv = process.env) {
   return (
@@ -49,8 +43,6 @@ export function sessionDevServer(env: NodeJS.ProcessEnv = process.env): ServerOp
     throw new Error(`Missing dev TLS certificate in ${dir}. Run "pnpm setup:dev-session" first.`);
   }
 
-  const target = mode === 'local' ? LOCAL_USER_SERVICE : 'https://relisten.net';
-
   return {
     host: '127.0.0.1',
     port: 5173,
@@ -59,30 +51,5 @@ export function sessionDevServer(env: NodeJS.ProcessEnv = process.env): ServerOp
     allowedHosts: ['web.relisten.localhost'],
     origin: LOCAL_WEB_ORIGIN,
     hmr: { host: 'web.relisten.localhost', protocol: 'wss', clientPort: 5173 },
-    proxy: Object.fromEntries(
-      SESSION_PROXY_ROUTES.map((route) => [
-        route,
-        {
-          target,
-          changeOrigin: true,
-          // Node trusts the mkcert CA via --use-system-ca (see the dev:session script).
-          secure: true,
-          followRedirects: false,
-          // Lowercase on purpose: incoming header keys are lowercase, so this
-          // overwrites a browser-supplied value instead of sending two.
-          headers: { 'x-relisten-web-origin': LOCAL_WEB_ORIGIN },
-          configure(proxy) {
-            proxy.on('proxyReq', (proxyReq) => {
-              // The User Service rejects requests carrying stray relay/forwarding headers.
-              for (const name of proxyReq.getHeaderNames()) {
-                if (name === 'forwarded' || name.startsWith('x-forwarded-')) {
-                  proxyReq.removeHeader(name);
-                }
-              }
-            });
-          },
-        },
-      ])
-    ),
   };
 }

--- a/dev/sessionDevServer.ts
+++ b/dev/sessionDevServer.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { ServerOptions } from 'vite';
+
+/**
+ * Opt-in dev-server config for browser sessions.
+ *
+ * The User Service only accepts two web origins (https://relisten.net and
+ * https://web.relisten.localhost:5173) and sets `__Host-` cookies, so local
+ * session development must run on that exact HTTPS origin with the session
+ * routes proxied same-origin. In production Traefik does this routing; in
+ * dev Vite's built-in proxy does.
+ *
+ * Enabled by `pnpm dev:session` (RELISTEN_WEB_SESSION=local|production).
+ * Plain `pnpm dev` is unaffected.
+ */
+
+export const LOCAL_WEB_ORIGIN = 'https://web.relisten.localhost:5173';
+const LOCAL_USER_SERVICE = 'https://accounts.relisten.localhost:5443';
+
+export const SESSION_PROXY_ROUTES = [
+  '^/auth/session(/|$)',
+  '^/api/user/v1/csrf$',
+  '^/v1/me$',
+  '^/v1/library(/|$)',
+];
+
+export function tlsDirectory(env: NodeJS.ProcessEnv = process.env) {
+  return (
+    env.RELISTEN_LOCAL_TLS_DIR ??
+    join(homedir(), 'Library', 'Application Support', 'Relisten', 'dev-tls')
+  );
+}
+
+export function sessionDevServer(env: NodeJS.ProcessEnv = process.env): ServerOptions | undefined {
+  const mode = env.RELISTEN_WEB_SESSION;
+  if (!mode) return undefined;
+  if (mode !== 'local' && mode !== 'production') {
+    throw new Error('RELISTEN_WEB_SESSION must be "local" or "production".');
+  }
+
+  const dir = tlsDirectory(env);
+  let cert: Buffer, key: Buffer;
+  try {
+    cert = readFileSync(join(dir, 'relisten-local.pem'));
+    key = readFileSync(join(dir, 'relisten-local-key.pem'));
+  } catch {
+    throw new Error(`Missing dev TLS certificate in ${dir}. Run "pnpm setup:dev-session" first.`);
+  }
+
+  const target = mode === 'local' ? LOCAL_USER_SERVICE : 'https://relisten.net';
+
+  return {
+    host: '127.0.0.1',
+    port: 5173,
+    strictPort: true,
+    https: { cert, key },
+    allowedHosts: ['web.relisten.localhost'],
+    origin: LOCAL_WEB_ORIGIN,
+    hmr: { host: 'web.relisten.localhost', protocol: 'wss', clientPort: 5173 },
+    proxy: Object.fromEntries(
+      SESSION_PROXY_ROUTES.map((route) => [
+        route,
+        {
+          target,
+          changeOrigin: true,
+          // Node trusts the mkcert CA via --use-system-ca (see the dev:session script).
+          secure: true,
+          followRedirects: false,
+          // Lowercase on purpose: incoming header keys are lowercase, so this
+          // overwrites a browser-supplied value instead of sending two.
+          headers: { 'x-relisten-web-origin': LOCAL_WEB_ORIGIN },
+          configure(proxy) {
+            proxy.on('proxyReq', (proxyReq) => {
+              // The User Service rejects requests carrying stray relay/forwarding headers.
+              for (const name of proxyReq.getHeaderNames()) {
+                if (name === 'forwarded' || name.startsWith('x-forwarded-')) {
+                  proxyReq.removeHeader(name);
+                }
+              }
+            });
+          },
+        },
+      ])
+    ),
+  };
+}

--- a/docs/dev-session.md
+++ b/docs/dev-session.md
@@ -10,9 +10,13 @@ Proxied paths: `/auth/session/*`, `/api/user/v1/csrf`, `/v1/me`, `/v1/library/*`
 ## One-time setup
 
 ```sh
-brew install mkcert
+brew install mkcert nss     # nss (certutil) is only needed so Firefox trusts the CA too
 pnpm setup:dev-session      # trusts a local CA, issues the cert, configures the User Service
 ```
+
+Firefox keeps its own trust store: without `nss` installed before `mkcert -install`
+it shows "Something doesn't look right". Install `nss`, rerun `mkcert -install`,
+and restart Firefox.
 
 The cert lives in `~/Library/Application Support/Relisten/dev-tls` (override with
 `RELISTEN_LOCAL_TLS_DIR`). The script also writes the cert paths and a stable

--- a/docs/dev-session.md
+++ b/docs/dev-session.md
@@ -3,7 +3,8 @@
 Plain `pnpm dev` needs nothing extra. Sign-in, `/account`, and favorites need the
 Relisten User Service reachable *same-origin* on the one local origin it accepts,
 `https://web.relisten.localhost:5173`. In production Traefik routes these paths to
-the User Service; locally Vite's proxy does (`dev/sessionDevServer.ts`).
+the User Service; locally `app/proxy.ts` forwards them (`src/lib/session/proxy.ts`) —
+timber handles requests before Vite's own `server.proxy`, so that can't be used.
 
 Proxied paths: `/auth/session/*`, `/api/user/v1/csrf`, `/v1/me`, `/v1/library/*`.
 

--- a/docs/dev-session.md
+++ b/docs/dev-session.md
@@ -37,7 +37,10 @@ persona. `dev:session` runs Node with `--use-system-ca` so both the Vite proxy a
 server-side `fetch` trust the mkcert CA without any CA-file plumbing.
 
 `RELISTEN_WEB_SESSION=production pnpm dev:session` proxies to `https://relisten.net`
-instead — only once the production session routes are deployed.
+instead, so you only need mkcert — no .NET, databases, or Google credentials. Google
+still returns to `https://auth.relisten.net/signin-google`, so no Google Console change
+is needed. This creates real production sessions: sign out when done and don't
+mutate favorites unless you mean to.
 
 ## Code map
 

--- a/docs/dev-session.md
+++ b/docs/dev-session.md
@@ -1,0 +1,48 @@
+# Local browser sessions
+
+Plain `pnpm dev` needs nothing extra. Sign-in, `/account`, and favorites need the
+Relisten User Service reachable *same-origin* on the one local origin it accepts,
+`https://web.relisten.localhost:5173`. In production Traefik routes these paths to
+the User Service; locally Vite's proxy does (`dev/sessionDevServer.ts`).
+
+Proxied paths: `/auth/session/*`, `/api/user/v1/csrf`, `/v1/me`, `/v1/library/*`.
+
+## One-time setup
+
+```sh
+brew install mkcert
+pnpm setup:dev-session      # trusts a local CA, issues the cert, configures the User Service
+```
+
+The cert lives in `~/Library/Application Support/Relisten/dev-tls` (override with
+`RELISTEN_LOCAL_TLS_DIR`). The script also writes the cert paths and a stable
+OpenIddict client secret into the User Service's `dotnet user-secrets` store; it
+expects the API checkout at `../RelistenApi` (override with `RELISTEN_API_CHECKOUT`).
+
+## Running
+
+```sh
+cd ../RelistenApi && ./start-local-databases.sh
+cd ../RelistenApi && dotnet run --project RelistenUserService/RelistenUserService.csproj
+pnpm dev:session
+```
+
+Open <https://web.relisten.localhost:5173/account> and sign in with a development
+persona. `dev:session` runs Node with `--use-system-ca` so both the Vite proxy and
+server-side `fetch` trust the mkcert CA without any CA-file plumbing.
+
+`RELISTEN_WEB_SESSION=production pnpm dev:session` proxies to `https://relisten.net`
+instead — only once the production session routes are deployed.
+
+## Code map
+
+- `src/lib/session/server.ts` — `getCurrentUser()` (React.cache, reads the
+  `__Host-relisten_session` cookie and calls `/v1/me` with the web-origin relay
+  header), library reads, and CSRF-protected mutations.
+- `src/lib/session/actions.ts` — server actions (`signOut`, `switchAccount`).
+  They relay the User Service's `Set-Cookie` clears via `getCookieJar().setFromHeaders`.
+- `src/app/(content)/account/page.tsx` — sign-in link / signed-in state.
+- Sign-in is just a link to `/auth/session/start?return_to=…`; no client JS.
+
+Server-side config (`src/lib/session/config.ts`): `RELISTEN_WEB_ORIGIN`,
+`RELISTEN_USER_SERVICE_URL`, `RELISTEN_AUTH_ORIGIN`.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "start": "timber preview",
     "lint": "oxlint src/**/*.ts src/**/*.tsx",
     "typecheck": "tsc --noEmit",
-    "dev:session": "RELISTEN_WEB_SESSION=local NODE_OPTIONS=--use-system-ca vite",
+    "dev:session": "RELISTEN_WEB_SESSION=${RELISTEN_WEB_SESSION:-local} NODE_OPTIONS=--use-system-ca vite",
     "setup:dev-session": "node scripts/setup-dev-session.mjs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "build": "NODE_ENV=production vite build",
     "start": "timber preview",
     "lint": "oxlint src/**/*.ts src/**/*.tsx",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "dev:session": "RELISTEN_WEB_SESSION=local NODE_OPTIONS=--use-system-ca vite",
+    "setup:dev-session": "node scripts/setup-dev-session.mjs"
   },
   "dependencies": {
     "@base-ui/react": "^1.7.0",

--- a/scripts/setup-dev-session.mjs
+++ b/scripts/setup-dev-session.mjs
@@ -47,6 +47,12 @@ if (spawnSync('mkcert', ['-version'], { stdio: 'ignore' }).error) {
   fail('mkcert is required: brew install mkcert');
 }
 
+if (spawnSync('certutil', ['-H'], { stdio: 'ignore' }).error) {
+  console.warn(
+    'certutil not found: Firefox will not trust the local CA. brew install nss, then rerun.'
+  );
+}
+
 mkdirSync(tlsDir, { recursive: true, mode: 0o700 });
 run('mkcert', ['-install']);
 run('mkcert', ['-cert-file', certPath, '-key-file', keyPath, ...HOSTS]);

--- a/scripts/setup-dev-session.mjs
+++ b/scripts/setup-dev-session.mjs
@@ -1,0 +1,79 @@
+// One-time setup for `pnpm dev:session`:
+//  1. mkcert: trust a local CA and issue one cert for the local web/auth/accounts hosts.
+//  2. Point the local RelistenUserService at that cert and a stable OpenIddict client secret
+//     via `dotnet user-secrets` (nothing is printed or passed as an argument).
+//
+// Only step 1 is strictly this repo's concern; step 2 is here for convenience until
+// RelistenApi grows its own bootstrap script.
+import { randomBytes } from 'node:crypto';
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const HOSTS = [
+  'localhost',
+  'web.relisten.localhost',
+  'auth.relisten.localhost',
+  'accounts.relisten.localhost',
+];
+
+const webCheckout = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const apiProject = join(
+  resolve(process.env.RELISTEN_API_CHECKOUT ?? join(webCheckout, '..', 'RelistenApi')),
+  'RelistenUserService',
+  'RelistenUserService.csproj'
+);
+const tlsDir =
+  process.env.RELISTEN_LOCAL_TLS_DIR ??
+  join(homedir(), 'Library', 'Application Support', 'Relisten', 'dev-tls');
+const certPath = join(tlsDir, 'relisten-local.pem');
+const keyPath = join(tlsDir, 'relisten-local-key.pem');
+const secretPath = join(tlsDir, 'web-client-secret');
+
+function run(cmd, args, opts = {}) {
+  const r = spawnSync(cmd, args, { stdio: 'inherit', ...opts });
+  if (r.error?.code === 'ENOENT') fail(`${cmd} is not installed.`);
+  if (r.error || r.status !== 0) fail(`${cmd} ${args[0]} failed.`);
+  return r;
+}
+function fail(msg) {
+  console.error(msg);
+  process.exit(1);
+}
+
+if (spawnSync('mkcert', ['-version'], { stdio: 'ignore' }).error) {
+  fail('mkcert is required: brew install mkcert');
+}
+
+mkdirSync(tlsDir, { recursive: true, mode: 0o700 });
+run('mkcert', ['-install']);
+run('mkcert', ['-cert-file', certPath, '-key-file', keyPath, ...HOSTS]);
+chmodSync(keyPath, 0o600);
+
+// Reused across runs: the local OpenIddict client stores a hash of this value,
+// so rotating it would break an existing local database.
+if (!existsSync(secretPath)) {
+  writeFileSync(secretPath, randomBytes(32).toString('base64url') + '\n', { mode: 0o600 });
+}
+const clientSecret = readFileSync(secretPath, 'utf8').trim();
+
+if (!existsSync(apiProject)) {
+  console.warn(
+    `RelistenUserService project not found at ${apiProject}; skipping dotnet user-secrets.`
+  );
+  console.warn('Set RELISTEN_API_CHECKOUT and rerun to configure the User Service.');
+} else {
+  const secrets = {
+    'Accounts:WebClientSecret': clientSecret,
+    'Kestrel:Certificates:Default:Path': certPath,
+    'Kestrel:Certificates:Default:KeyPath': keyPath,
+  };
+  run('dotnet', ['user-secrets', 'set', '--project', apiProject], {
+    input: JSON.stringify(secrets),
+    stdio: ['pipe', 'ignore', 'inherit'],
+  });
+}
+
+console.log(`Dev session TLS ready in ${tlsDir}. Start with: pnpm dev:session`);

--- a/src/app/(content)/account/page.tsx
+++ b/src/app/(content)/account/page.tsx
@@ -1,0 +1,44 @@
+import { getCurrentUser, getLibrarySnapshot, signInHref } from '@/lib/session/server';
+import { signOut, switchAccount } from '@/lib/session/actions';
+
+export const metadata = { title: 'Account' };
+
+export default async function AccountPage() {
+  const user = await getCurrentUser();
+
+  if (!user) {
+    return (
+      <div className="content">
+        <h1>Account</h1>
+        <p>Sign in to sync your favorites across the web and the apps.</p>
+        <a href={signInHref('/account')} className="underline">
+          Sign in with Relisten
+        </a>
+      </div>
+    );
+  }
+
+  const library = await getLibrarySnapshot().catch(() => null);
+
+  return (
+    <div className="content">
+      <h1>Account</h1>
+      <p>
+        Signed in as <strong>{user.username}</strong>
+        {library ? ` · ${library.favorites.length} favorites` : null}
+      </p>
+      <div className="flex gap-4">
+        <form action={signOut}>
+          <button type="submit" className="underline">
+            Sign out
+          </button>
+        </form>
+        <form action={switchAccount}>
+          <button type="submit" className="underline">
+            Switch account
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(content)/account/page.tsx
+++ b/src/app/(content)/account/page.tsx
@@ -1,7 +1,14 @@
+import { Suspense } from 'react';
 import { getCurrentUser, getLibrarySnapshot, signInHref } from '@/lib/session/server';
-import { signOut, switchAccount } from '@/lib/session/actions';
+import SessionForms from '@/components/SessionForms';
 
 export const metadata = { title: 'Account' };
+
+// Streams in after the shell: the library call must not hold the flush point.
+async function FavoritesCount() {
+  const library = await getLibrarySnapshot();
+  return library ? <> · {library.favorites.length} favorites</> : ' · favorites unavailable';
+}
 
 export default async function AccountPage() {
   const user = await getCurrentUser();
@@ -18,27 +25,16 @@ export default async function AccountPage() {
     );
   }
 
-  const library = await getLibrarySnapshot().catch(() => null);
-
   return (
     <div className="content">
       <h1>Account</h1>
       <p>
         Signed in as <strong>{user.username}</strong>
-        {library ? ` · ${library.favorites.length} favorites` : null}
+        <Suspense fallback={null}>
+          <FavoritesCount />
+        </Suspense>
       </p>
-      <div className="flex gap-4">
-        <form action={signOut}>
-          <button type="submit" className="underline">
-            Sign out
-          </button>
-        </form>
-        <form action={switchAccount}>
-          <button type="submit" className="underline">
-            Switch account
-          </button>
-        </form>
-      </div>
+      <SessionForms />
     </div>
   );
 }

--- a/src/app/proxy.ts
+++ b/src/app/proxy.ts
@@ -1,3 +1,5 @@
+import { proxySessionRequest } from '@/lib/session/proxy';
+
 export default async (req: Request, next: () => Promise<Response>) => {
   const start = performance.now();
   const url = new URL(req.url);
@@ -9,6 +11,9 @@ export default async (req: Request, next: () => Promise<Response>) => {
     'unknown';
   const host = req.headers.get('host') ?? req.headers.get('x-forwarded-host') ?? 'unknown';
   const ua = req.headers.get('user-agent') ?? 'unknown';
+
+  const session = await proxySessionRequest(req);
+  if (session) return session;
 
   if (url.pathname === '/privacy-policy') {
     const file = await fetch(new URL('/privacy_policy.html', req.url));

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -7,6 +7,7 @@ const Menu = () => (
     <Row href="/">Home</Row>
     <Row href="/blog">Blog</Row>
     <Row href="/about">About</Row>
+    <Row href="/account">Account</Row>
     <Row href="/today">Today</Row>
     <Row href="/recently-played">Live</Row>
     <Row href="/app">Apps</Row>

--- a/src/components/SessionForms.tsx
+++ b/src/components/SessionForms.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useActionState } from '@timber-js/app/client';
+import { signOut, switchAccount } from '@/lib/session/actions';
+
+const MESSAGES: Record<string, string> = {
+  SESSION_REJECTED: 'The account service rejected the request. Reload and try again.',
+  SESSION_UNAVAILABLE: 'The account service is temporarily unavailable.',
+};
+
+function SessionButton({ action, label }: { action: typeof signOut; label: string }) {
+  const [, formAction, pending, errors] = useActionState(action, null);
+  const error = errors.serverError?.code;
+  return (
+    <form action={formAction}>
+      <button type="submit" disabled={pending} className="underline disabled:opacity-50">
+        {pending ? `${label}…` : label}
+      </button>
+      {error && (
+        <p className="mt-1 text-sm text-red-500">{MESSAGES[error] ?? 'Something went wrong.'}</p>
+      )}
+    </form>
+  );
+}
+
+export default function SessionForms() {
+  return (
+    <div className="flex gap-4">
+      <SessionButton action={signOut} label="Sign out" />
+      <SessionButton action={switchAccount} label="Switch account" />
+    </div>
+  );
+}

--- a/src/lib/session/actions.ts
+++ b/src/lib/session/actions.ts
@@ -1,0 +1,21 @@
+'use server';
+
+import { createActionClient, redirectExternal } from '@timber-js/app/server';
+import { AUTH_ORIGIN } from './config';
+import { logoutSession, switchAccountSession } from './server';
+
+const sessionAction = createActionClient({});
+
+// The User Service answers with a navigation_url on the auth host that clears the
+// SSO cookie and then returns to the web origin. Nothing else may be a target.
+const navigate = (url: string) => redirectExternal(url, [AUTH_ORIGIN]);
+
+export const signOut = sessionAction.action(async () => {
+  const { navigation_url } = await logoutSession();
+  navigate(navigation_url);
+});
+
+export const switchAccount = sessionAction.action(async () => {
+  const { navigation_url } = await switchAccountSession('/account');
+  navigate(navigation_url);
+});

--- a/src/lib/session/actions.ts
+++ b/src/lib/session/actions.ts
@@ -1,8 +1,14 @@
 'use server';
 
-import { createActionClient, redirectExternal } from '@timber-js/app/server';
-import { AUTH_ORIGIN } from './config';
-import { logoutSession, switchAccountSession } from './server';
+import {
+  ActionError,
+  createActionClient,
+  getCookieJar,
+  redirect,
+  redirectExternal,
+} from '@timber-js/app/server';
+import { AUTH_ORIGIN, CSRF_COOKIE, SESSION_COOKIE } from './config';
+import { logoutSession, switchAccountSession, UserServiceError } from './server';
 
 const sessionAction = createActionClient({});
 
@@ -10,12 +16,32 @@ const sessionAction = createActionClient({});
 // SSO cookie and then returns to the web origin. Nothing else may be a target.
 const navigate = (url: string) => redirectExternal(url, [AUTH_ORIGIN]);
 
-export const signOut = sessionAction.action(async () => {
-  const { navigation_url } = await logoutSession();
-  navigate(navigation_url);
-});
+/**
+ * Run a session mutation and follow its navigation_url. A 401 means the session
+ * is already gone (revoked elsewhere / expired): drop the dead cookies and land
+ * on /account signed out. A 403 is a CSRF/origin failure on a live session and
+ * anything else is an outage — surface both, keep the cookies.
+ */
+async function runSessionNavigation(mutation: () => Promise<{ navigation_url: string }>) {
+  let navigationUrl: string;
+  try {
+    navigationUrl = (await mutation()).navigation_url;
+  } catch (err) {
+    if (err instanceof UserServiceError && err.status === 401) {
+      const jar = getCookieJar();
+      jar.delete(SESSION_COOKIE);
+      jar.delete(CSRF_COOKIE);
+      redirect('/account');
+    }
+    const status = err instanceof UserServiceError ? err.status : undefined;
+    console.error('[session] mutation failed', err);
+    throw new ActionError(status === 403 ? 'SESSION_REJECTED' : 'SESSION_UNAVAILABLE');
+  }
+  navigate(navigationUrl);
+}
 
-export const switchAccount = sessionAction.action(async () => {
-  const { navigation_url } = await switchAccountSession('/account');
-  navigate(navigation_url);
-});
+export const signOut = sessionAction.action(() => runSessionNavigation(logoutSession));
+
+export const switchAccount = sessionAction.action(() =>
+  runSessionNavigation(() => switchAccountSession('/account'))
+);

--- a/src/lib/session/config.ts
+++ b/src/lib/session/config.ts
@@ -1,6 +1,8 @@
 import 'server-only';
 
 const dev = process.env.NODE_ENV !== 'production';
+// `pnpm dev:session` sets this to "local" (dotnet run) or "production" (relisten.net).
+const localBackend = dev && process.env.RELISTEN_WEB_SESSION !== 'production';
 
 /** The browser-visible origin the User Service should reconstruct callbacks against. */
 export const WEB_ORIGIN =
@@ -8,21 +10,21 @@ export const WEB_ORIGIN =
   (dev ? 'https://web.relisten.localhost:5173' : 'https://relisten.net');
 
 /**
- * Where server-side session lookups go. Must present as the accounts host to the
- * User Service (its relay middleware only honours X-Relisten-Web-Origin from there).
- * In-cluster this is the user-service Service behind Traefik; locally it's the
- * `dotnet run` HTTPS endpoint.
+ * Where server-side session lookups go. The User Service only honours the
+ * X-Relisten-Web-Origin relay from its accounts host or a configured web origin,
+ * so this is either the local `dotnet run` endpoint, relisten.net itself (Traefik
+ * routes the session paths), or the in-cluster service.
  */
 export const USER_SERVICE_URL =
   process.env.RELISTEN_USER_SERVICE_URL ??
-  (dev ? 'https://accounts.relisten.localhost:5443' : 'https://accounts.relisten.net');
+  (localBackend ? 'https://accounts.relisten.localhost:5443' : 'https://relisten.net');
+
+/** The OIDC issuer / SSO-cookie host. Logout bounces through it to clear the SSO cookie. */
+export const AUTH_ORIGIN =
+  process.env.RELISTEN_AUTH_ORIGIN ??
+  (localBackend ? 'https://auth.relisten.localhost:5443' : 'https://auth.relisten.net');
 
 export const SESSION_COOKIE = '__Host-relisten_session';
 export const CSRF_COOKIE = '__Host-relisten_csrf';
 export const CSRF_HEADER = 'X-Relisten-CSRF';
 export const WEB_ORIGIN_HEADER = 'X-Relisten-Web-Origin';
-
-/** The OIDC issuer / SSO-cookie host. Logout bounces through it to clear the SSO cookie. */
-export const AUTH_ORIGIN =
-  process.env.RELISTEN_AUTH_ORIGIN ??
-  (dev ? 'https://auth.relisten.localhost:5443' : 'https://auth.relisten.net');

--- a/src/lib/session/config.ts
+++ b/src/lib/session/config.ts
@@ -1,0 +1,28 @@
+import 'server-only';
+
+const dev = process.env.NODE_ENV !== 'production';
+
+/** The browser-visible origin the User Service should reconstruct callbacks against. */
+export const WEB_ORIGIN =
+  process.env.RELISTEN_WEB_ORIGIN ??
+  (dev ? 'https://web.relisten.localhost:5173' : 'https://relisten.net');
+
+/**
+ * Where server-side session lookups go. Must present as the accounts host to the
+ * User Service (its relay middleware only honours X-Relisten-Web-Origin from there).
+ * In-cluster this is the user-service Service behind Traefik; locally it's the
+ * `dotnet run` HTTPS endpoint.
+ */
+export const USER_SERVICE_URL =
+  process.env.RELISTEN_USER_SERVICE_URL ??
+  (dev ? 'https://accounts.relisten.localhost:5443' : 'https://accounts.relisten.net');
+
+export const SESSION_COOKIE = '__Host-relisten_session';
+export const CSRF_COOKIE = '__Host-relisten_csrf';
+export const CSRF_HEADER = 'X-Relisten-CSRF';
+export const WEB_ORIGIN_HEADER = 'X-Relisten-Web-Origin';
+
+/** The OIDC issuer / SSO-cookie host. Logout bounces through it to clear the SSO cookie. */
+export const AUTH_ORIGIN =
+  process.env.RELISTEN_AUTH_ORIGIN ??
+  (dev ? 'https://auth.relisten.localhost:5443' : 'https://auth.relisten.net');

--- a/src/lib/session/proxy.ts
+++ b/src/lib/session/proxy.ts
@@ -22,7 +22,24 @@ const ROUTES = [
 ];
 
 // Hop-by-hop plus anything that could influence the User Service's origin reconstruction.
-const DROP = new Set(['host', 'connection', 'keep-alive', 'transfer-encoding', 'forwarded']);
+const DROP = new Set([
+  'host',
+  'connection',
+  'keep-alive',
+  'transfer-encoding',
+  'te',
+  'upgrade',
+  'forwarded',
+  'accept-encoding',
+]);
+// undici transparently decompresses, so these no longer describe the relayed body.
+const RESPONSE_DROP = [
+  'content-encoding',
+  'content-length',
+  'transfer-encoding',
+  'connection',
+  'keep-alive',
+];
 
 export function isSessionRoute(pathname: string): boolean {
   return ROUTES.some((route) => route.test(pathname));
@@ -39,6 +56,8 @@ export async function proxySessionRequest(req: Request): Promise<Response | null
     headers.set(name, value);
   });
   headers.set(WEB_ORIGIN_HEADER, WEB_ORIGIN);
+  // Dev only: ask for plaintext so no decode/re-encode mismatch is possible.
+  headers.set('accept-encoding', 'identity');
 
   const hasBody = req.method !== 'GET' && req.method !== 'HEAD';
   try {
@@ -51,16 +70,32 @@ export async function proxySessionRequest(req: Request): Promise<Response | null
       redirect: 'manual',
       cache: 'no-store',
     });
+    const responseHeaders = new Headers();
+    upstream.headers.forEach((value, name) => {
+      if (name !== 'set-cookie' && !RESPONSE_DROP.includes(name)) responseHeaders.set(name, value);
+    });
+    // Keep every Set-Cookie separate (the callback sets the session and CSRF cookies).
+    for (const cookie of upstream.headers.getSetCookie())
+      responseHeaders.append('set-cookie', cookie);
     return new Response(upstream.body, {
       status: upstream.status,
       statusText: upstream.statusText,
-      headers: upstream.headers,
+      headers: responseHeaders,
     });
   } catch (err) {
-    console.error('[session-proxy] User Service unreachable', err);
-    return new Response('Session service unavailable.', {
-      status: 502,
-      headers: { 'cache-control': 'private, no-store' },
-    });
+    const cause =
+      err instanceof Error && err.cause instanceof Error ? err.cause.message : String(err);
+    console.error(`[session-proxy] ${TARGET} unreachable: ${cause}`);
+    return new Response(
+      `Session service unavailable at ${TARGET}: ${cause}\n` +
+        'Is RelistenUserService running and is the mkcert CA trusted (dev:session uses --use-system-ca)? See docs/dev-session.md.',
+      {
+        status: 502,
+        headers: {
+          'cache-control': 'private, no-store',
+          'content-type': 'text/plain; charset=utf-8',
+        },
+      }
+    );
   }
 }

--- a/src/lib/session/proxy.ts
+++ b/src/lib/session/proxy.ts
@@ -1,0 +1,66 @@
+import 'server-only';
+
+import { USER_SERVICE_URL, WEB_ORIGIN, WEB_ORIGIN_HEADER } from './config';
+
+/**
+ * Same-origin forwarding of the browser-session routes to the User Service.
+ *
+ * In production Traefik routes these paths before they reach timber. In local
+ * development (`pnpm dev:session`) this runs from app/proxy.ts instead — it has to
+ * live here rather than in Vite's `server.proxy`, because timber's dev middleware
+ * handles requests before Vite's proxy middleware gets a chance.
+ */
+
+// Only forward when explicitly in a session dev mode; in production Traefik owns these paths.
+const TARGET = process.env.RELISTEN_WEB_SESSION ? USER_SERVICE_URL : null;
+
+const ROUTES = [
+  /^\/auth\/session(\/|$)/,
+  /^\/api\/user\/v1\/csrf$/,
+  /^\/v1\/me$/,
+  /^\/v1\/library(\/|$)/,
+];
+
+// Hop-by-hop plus anything that could influence the User Service's origin reconstruction.
+const DROP = new Set(['host', 'connection', 'keep-alive', 'transfer-encoding', 'forwarded']);
+
+export function isSessionRoute(pathname: string): boolean {
+  return ROUTES.some((route) => route.test(pathname));
+}
+
+export async function proxySessionRequest(req: Request): Promise<Response | null> {
+  if (!TARGET) return null;
+  const url = new URL(req.url);
+  if (!isSessionRoute(url.pathname)) return null;
+
+  const headers = new Headers();
+  req.headers.forEach((value, name) => {
+    if (DROP.has(name) || name.startsWith('x-forwarded-')) return;
+    headers.set(name, value);
+  });
+  headers.set(WEB_ORIGIN_HEADER, WEB_ORIGIN);
+
+  const hasBody = req.method !== 'GET' && req.method !== 'HEAD';
+  try {
+    const upstream = await fetch(`${TARGET}${url.pathname}${url.search}`, {
+      method: req.method,
+      headers,
+      body: hasBody ? req.body : undefined,
+      // @ts-expect-error -- required by undici for streamed request bodies
+      duplex: hasBody ? 'half' : undefined,
+      redirect: 'manual',
+      cache: 'no-store',
+    });
+    return new Response(upstream.body, {
+      status: upstream.status,
+      statusText: upstream.statusText,
+      headers: upstream.headers,
+    });
+  } catch (err) {
+    console.error('[session-proxy] User Service unreachable', err);
+    return new Response('Session service unavailable.', {
+      status: 502,
+      headers: { 'cache-control': 'private, no-store' },
+    });
+  }
+}

--- a/src/lib/session/server.ts
+++ b/src/lib/session/server.ts
@@ -1,0 +1,110 @@
+import 'server-only';
+
+import { cache } from 'react';
+import { getCookieJar } from '@timber-js/app/server';
+import {
+  CSRF_COOKIE,
+  CSRF_HEADER,
+  SESSION_COOKIE,
+  USER_SERVICE_URL,
+  WEB_ORIGIN,
+  WEB_ORIGIN_HEADER,
+} from './config';
+import type {
+  AccountProfile,
+  FavoriteMutation,
+  FavoriteMutationBatchResponse,
+  LibrarySnapshot,
+  SessionNavigation,
+} from './types';
+
+export class UserServiceError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly path: string
+  ) {
+    super(`User Service ${path} responded ${status}`);
+  }
+}
+
+/** Forward the browser's session cookies to the User Service. Never cached. */
+export async function userServiceFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const jar = getCookieJar();
+  const cookie = [SESSION_COOKIE, CSRF_COOKIE]
+    .map((name) => {
+      const value = jar.get(name);
+      return value === undefined ? null : `${name}=${value}`;
+    })
+    .filter(Boolean)
+    .join('; ');
+
+  const headers = new Headers(init.headers);
+  headers.set('accept', 'application/json');
+  headers.set(WEB_ORIGIN_HEADER, WEB_ORIGIN);
+  if (cookie) headers.set('cookie', cookie);
+  // Cookie-authenticated unsafe requests must carry the exact web origin.
+  if (init.method && init.method !== 'GET') headers.set('origin', WEB_ORIGIN);
+
+  return fetch(`${USER_SERVICE_URL}${path}`, { ...init, headers, cache: 'no-store' });
+}
+
+async function json<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await userServiceFetch(path, init);
+  if (!res.ok) throw new UserServiceError(res.status, path);
+  return (await res.json()) as T;
+}
+
+/**
+ * The signed-in user for this request, or null. Deduplicated per render via
+ * React.cache so layouts, access.ts, and pages can all call it freely.
+ */
+export const getCurrentUser = cache(async (): Promise<AccountProfile | null> => {
+  if (!getCookieJar().has(SESSION_COOKIE)) return null;
+  try {
+    return await json<AccountProfile>('/v1/me');
+  } catch (err) {
+    if (err instanceof UserServiceError && err.status === 401) return null;
+    console.error('[session] /v1/me failed', err);
+    return null;
+  }
+});
+
+export const getLibrarySnapshot = cache(() => json<LibrarySnapshot>('/v1/library/snapshot'));
+
+async function csrfToken(): Promise<string> {
+  const { request_token } = await json<{ request_token: string }>('/api/user/v1/csrf');
+  return request_token;
+}
+
+/** POST with a session-bound CSRF token, relaying any Set-Cookie back to the browser. */
+async function mutate<T>(path: string, body?: unknown): Promise<T> {
+  const token = await csrfToken();
+  const headers: Record<string, string> = { [CSRF_HEADER]: token };
+  if (body !== undefined) headers['content-type'] = 'application/json';
+  const res = await userServiceFetch(path, {
+    method: 'POST',
+    headers,
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  getCookieJar().setFromHeaders(res.headers);
+  if (!res.ok) throw new UserServiceError(res.status, path);
+  return (await res.json()) as T;
+}
+
+export const logoutSession = () => mutate<SessionNavigation>('/auth/session/logout');
+
+export const switchAccountSession = (returnTo = '/') =>
+  mutate<SessionNavigation>(
+    `/auth/session/switch-account?${new URLSearchParams({ return_to: returnTo })}`
+  );
+
+export const mutateFavorites = (mutations: FavoriteMutation[]) =>
+  mutate<FavoriteMutationBatchResponse>('/v1/library/favorite-mutations:batch', {
+    contract_version: 1,
+    mutations,
+  });
+
+/** Same-origin entry point for sign-in; safe to use as a plain <a href>. */
+export function signInHref(returnTo = '/'): string {
+  return `/auth/session/start?${new URLSearchParams({ return_to: returnTo })}`;
+}

--- a/src/lib/session/server.ts
+++ b/src/lib/session/server.ts
@@ -54,9 +54,19 @@ async function json<T>(path: string, init?: RequestInit): Promise<T> {
   return (await res.json()) as T;
 }
 
+/** Thrown when the User Service is down/erroring for a request that carries a session cookie. */
+export class SessionUnavailableError extends Error {
+  constructor(cause: unknown) {
+    super('The account service is temporarily unavailable.', { cause });
+    this.name = 'SessionUnavailableError';
+  }
+}
+
 /**
- * The signed-in user for this request, or null. Deduplicated per render via
- * React.cache so layouts, access.ts, and pages can all call it freely.
+ * The signed-in user for this request, or null when there is no (valid) session.
+ * Deduplicated per render via React.cache so layouts, access.ts, and pages can
+ * all call it freely. Throws SessionUnavailableError on outages rather than
+ * pretending the user is signed out — let error.tsx render that state.
  */
 export const getCurrentUser = cache(async (): Promise<AccountProfile | null> => {
   if (!getCookieJar().has(SESSION_COOKIE)) return null;
@@ -65,18 +75,36 @@ export const getCurrentUser = cache(async (): Promise<AccountProfile | null> => 
   } catch (err) {
     if (err instanceof UserServiceError && err.status === 401) return null;
     console.error('[session] /v1/me failed', err);
+    throw new SessionUnavailableError(err);
+  }
+});
+
+/** The favorites library, or null if it could not be loaded (logged). */
+export const getLibrarySnapshot = cache(async (): Promise<LibrarySnapshot | null> => {
+  try {
+    return await json<LibrarySnapshot>('/v1/library/snapshot');
+  } catch (err) {
+    console.error('[session] /v1/library/snapshot failed', err);
     return null;
   }
 });
 
-export const getLibrarySnapshot = cache(() => json<LibrarySnapshot>('/v1/library/snapshot'));
-
+/** Mutable contexts only (actions / route handlers): relays the CSRF cookie. */
 async function csrfToken(): Promise<string> {
-  const { request_token } = await json<{ request_token: string }>('/api/user/v1/csrf');
+  const path = '/api/user/v1/csrf';
+  const res = await userServiceFetch(path);
+  // The antiforgery cookie is a browser-session cookie while the web session
+  // cookie is persistent, so after a browser restart GetAndStoreTokens mints a
+  // fresh __Host-relisten_csrf here. Relay it before the POST: the jar's
+  // read-your-own-writes makes the next userServiceFetch send the cookie the
+  // request token is bound to, and the browser receives it too.
+  getCookieJar().setFromHeaders(res.headers);
+  if (!res.ok) throw new UserServiceError(res.status, path);
+  const { request_token } = (await res.json()) as { request_token: string };
   return request_token;
 }
 
-/** POST with a session-bound CSRF token, relaying any Set-Cookie back to the browser. */
+/** POST with a session-bound CSRF token, relaying any Set-Cookie back to the browser. Actions only. */
 async function mutate<T>(path: string, body?: unknown): Promise<T> {
   const token = await csrfToken();
   const headers: Record<string, string> = { [CSRF_HEADER]: token };

--- a/src/lib/session/types.ts
+++ b/src/lib/session/types.ts
@@ -1,0 +1,64 @@
+// Mirrors Relisten.Accounts.Contracts in RelistenApi. Keep in sync (or generate).
+
+export type FavoriteCatalogType =
+  | 'artist'
+  | 'show'
+  | 'source'
+  | 'source_track'
+  | 'song'
+  | 'tour'
+  | 'venue';
+
+export interface AccountProfile {
+  contract_version: number;
+  user_uuid: string;
+  username: string;
+  username_version: number;
+  username_review_needed: boolean;
+  username_reviewed_at: string | null;
+  username_change_available_at: string | null;
+}
+
+export interface FavoriteItem {
+  favorite_uuid: string;
+  catalog_type: FavoriteCatalogType;
+  catalog_uuid: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface LibrarySnapshot {
+  contract_version: number;
+  library_revision: number;
+  next_cursor: string;
+  favorites: FavoriteItem[];
+}
+
+export interface FavoriteMutation {
+  mutation_uuid: string;
+  catalog_type: FavoriteCatalogType;
+  catalog_uuid: string;
+  desired_state: 'favorite' | 'not_favorite';
+  favorite_uuid: string | null;
+}
+
+export interface FavoriteMutationResult {
+  mutation_uuid: string;
+  catalog_type: FavoriteCatalogType;
+  catalog_uuid: string;
+  desired_state: 'favorite' | 'not_favorite';
+  changed: boolean;
+  submitted_favorite_uuid: string | null;
+  canonical_favorite_uuid: string | null;
+  library_revision: number;
+}
+
+export interface FavoriteMutationBatchResponse {
+  contract_version: number;
+  library_revision: number;
+  results: FavoriteMutationResult[];
+}
+
+export interface SessionNavigation {
+  navigation_url: string;
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'node:path';
 import { timber } from '@timber-js/app';
+import { sessionDevServer } from './dev/sessionDevServer';
 
 const serverExternals = ['takumi-js', '@takumi-rs/core', '@mdx-js/rollup', 'rollup', 'fsevents'];
 
@@ -26,7 +27,6 @@ export default defineConfig({
       },
     },
   },
-  server: {
-    strictPort: false,
-  },
+  // Opt-in HTTPS origin + same-origin session proxy (pnpm dev:session).
+  server: sessionDevServer() ?? { strictPort: false },
 });


### PR DESCRIPTION
## Summary

A slimmer, timber-native take on the browser-session work from #108 (reverted in #109). Same backend contract (RelistenApi #85): the four session path families are served same-origin, `__Host-` cookies, `X-Relisten-Web-Origin` relay. What changes is how the web side gets there.

**Compared with #108**

| | #108 | this branch |
|---|---|---|
| `pnpm dev` | requires mkcert + .NET + `../RelistenApi` for everyone | unchanged; sessions are opt-in via `pnpm dev:session` |
| proxy | custom `http-proxy-3` Vite plugin + 258-line test of its path matching | forwarding in `app/proxy.ts` (`src/lib/session/proxy.ts`); timber's dev middleware runs before Vite's `server.proxy`, so that's the only place it can live |
| CA trust | copies `ca.pem`, passes it to the proxy | `NODE_OPTIONS=--use-system-ca` |
| session state | browser-only `BrowserSessionClient` class, unused | server-first: `getCurrentUser()` (React.cache + cookie jar), CSRF mutations, logout/switch-account as server actions |
| UI | dev-only diagnostic page | `/account` page + menu link |
| new deps | `http-proxy-3`, `vitest`, `@playwright/test` | none |
| size | 16 files, +1,551 | 15 files, +650 |

## How it works

- `pnpm setup:dev-session` — mkcert cert for the local hosts; writes cert paths + a stable OpenIddict client secret to the User Service's `dotnet user-secrets` if the API checkout exists (warns otherwise).
- `pnpm dev:session` — serves `https://web.relisten.localhost:5173`; `RELISTEN_WEB_SESSION=production pnpm dev:session` proxies to relisten.net so only mkcert is needed.
- `src/lib/session/server.ts` — `getCurrentUser()` reads `__Host-relisten_session` from the cookie jar and calls `/v1/me` with the origin relay header. Throws `SessionUnavailableError` on outages rather than rendering signed-out. `mutate()` fetches a CSRF token, relays its `Set-Cookie` (the antiforgery cookie is browser-session-scoped while the session cookie is persistent), POSTs with `X-Relisten-CSRF` + `Origin`, and relays the response cookies.
- `src/lib/session/actions.ts` — `signOut` / `switchAccount` follow the `navigation_url` via `redirectExternal` allow-listed to the auth host. 401 → drop cookies + redirect; 403/5xx → named `ActionError` shown by `SessionForms` (`useActionState`).
- Sign-in is a plain `<a href="/auth/session/start?return_to=…">`. No client JS.
- In production nothing here proxies — Traefik owns the paths, exactly as the API plan assumes.

## Verified

Against production: Google sign-in → callback → `/account` renders username + favorites count server-side → Sign out → `auth.relisten.net/auth/sso/clear` → back signed out. Chrome and Firefox (Firefox needs `brew install nss` before `mkcert -install`; documented).

A 4-lens agent review with adversarial verification produced 6 real findings (CSRF cookie relay, proxied `content-encoding`, action error paths, outage handling, flush point, dev error messages), all fixed in `cebc979`.

## Not done / follow-ups

- "Switch account" and `mutateFavorites` are implemented but not exercised (no UI calls favorites yet).
- The `dotnet user-secrets` half of the setup script belongs in RelistenApi.
- `src/lib/session/types.ts` is hand-mirrored from `Relisten.Accounts.Contracts`; should be generated.
- `.tool-versions`/`engines` should say Node 26 (`--use-system-ca` needs ≥ 22.15).
- Docs: `docs/dev-session.md`.
